### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ django-placeholder
 
 [![Code Health](https://landscape.io/github/mauler/django-placeholder/master/landscape.png)](https://landscape.io/github/mauler/django-placeholder/master)
 
-[![Latest PyPI version](https://img.shields.io/pypi/v/django-placeholder.svg
-
-[![Number of PyPI downloads](https://img.shields.io/pypi/dm/django-placeholder.svg
+[![Latest PyPI version](https://img.shields.io/pypi/v/django-placeholder.svg)](https://crate.io/packages/django-placeholder/)
 
 Yes, another project to create placeholders (inline editable content). The goal of this project is to be a simple (and stupid) tool to use placeholders on your project. It uses the default `django admin` (compatible with grappelli, suit and others) so you can reuse everything from admin. (forms, fields, widgets...)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ django-placeholder
 
 [![Code Health](https://landscape.io/github/mauler/django-placeholder/master/landscape.png)](https://landscape.io/github/mauler/django-placeholder/master)
 
-[![Latest PyPI version](https://pypip.in/v/django-placeholder/badge.png)](https://crate.io/packages/django-placeholder/)
+[![Latest PyPI version](https://img.shields.io/pypi/v/django-placeholder.svg
 
-[![Number of PyPI downloads](https://pypip.in/d/django-placeholder/badge.png)](https://crate.io/packages/django-placeholder/)
+[![Number of PyPI downloads](https://img.shields.io/pypi/dm/django-placeholder.svg
 
 Yes, another project to create placeholders (inline editable content). The goal of this project is to be a simple (and stupid) tool to use placeholders on your project. It uses the default `django admin` (compatible with grappelli, suit and others) so you can reuse everything from admin. (forms, fields, widgets...)
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-placeholder))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-placeholder`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.